### PR TITLE
いいねしたときにlikesTags重複無し追加保存

### DIFF
--- a/app/src/main/java/com/example/charactermatchingapp/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/data/auth/repository/AuthRepositoryImpl.kt
@@ -25,6 +25,7 @@ class AuthRepositoryImpl(
                     "bio" to null,
                     "likedCount" to 0,
                     "postsCount" to 0,
+                    "likesTags" to emptyList<String>(),
                     "createdAt" to Timestamp.now()
                 )
                 firestore.collection("accounts").document(uid).set(accountData).await()

--- a/app/src/main/java/com/example/charactermatchingapp/data/getProfile.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/data/getProfile.kt
@@ -13,12 +13,7 @@ class ProfileRepository {
             val document = db.collection("accounts").document(accountId).get().await()
             if (document.exists()) {
                 // ここでFirestoreのデータをProfileオブジェクトに変換する
-                Profile(
-                    accountName = document.getString("displayName") ?: "",
-                    headerImageResId = document.getString("headerImageUrl") ?: "",
-                    iconImageResId = document.getString("iconImageUrl") ?: "",
-                    profileText = document.getString("bio") ?: ""
-                )
+                document.toObject(Profile::class.java)
             } else {
                 null
             }

--- a/app/src/main/java/com/example/charactermatchingapp/data/matching/repository/CharacterMatchingRepositoryImpl.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/data/matching/repository/CharacterMatchingRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.example.charactermatchingapp.domain.auth.service.CurrentUserProvider
 import com.example.charactermatchingapp.domain.matching.model.CharacterInfo
 import com.example.charactermatchingapp.domain.matching.repository.CharacterMatchingRepository
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FieldValue
 import kotlinx.coroutines.tasks.await
 
 class CharacterMatchingRepositoryImpl(
@@ -86,5 +87,17 @@ class CharacterMatchingRepositoryImpl(
 
     override fun dislikeCharacterInfo(characterInfo: CharacterInfo) {
         TODO("Not yet implemented")
+    }
+
+    override suspend fun onCardLiked(userId: String, likedArtworkTags: List<String>): Result<Unit> {
+        return try {
+            firestore.collection("accounts").document(userId)
+                .update("likesTags", FieldValue.arrayUnion(*likedArtworkTags.toTypedArray()))
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("CharacterMatchingRepoImpl", "Error adding likesTags", e)
+            Result.failure(e)
+        }
     }
 }

--- a/app/src/main/java/com/example/charactermatchingapp/data/user/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/data/user/repository/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.example.charactermatchingapp.data.user.repository
 
 import com.example.charactermatchingapp.domain.user.repository.UserRepository
+import com.example.charactermatchingapp.domain.matching.model.Profile
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 
@@ -15,6 +16,39 @@ class UserRepositoryImpl(private val firestore: FirebaseFirestore) : UserReposit
             } else {
                 Result.success(emptyList()) // ドキュメントが存在しない場合は空のリストを返す
             }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getUserProfile(userId: String): Result<Profile> {
+        return try {
+            val document = firestore.collection("accounts").document(userId).get().await()
+            if (document.exists()) {
+                val profile = document.toObject(Profile::class.java)
+                if (profile != null) {
+                    Result.success(profile)
+                } else {
+                    Result.failure(Exception("Failed to parse user profile."))
+                }
+            } else {
+                Result.failure(Exception("User profile not found."))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateUserProfile(userId: String, profile: Profile): Result<Unit> {
+        return try {
+            val updates = hashMapOf<String, Any?>(
+                "displayName" to profile.displayName,
+                "iconImageUrl" to profile.iconImageUrl,
+                "headerImageUrl" to profile.headerImageUrl,
+                "bio" to profile.bio
+            )
+            firestore.collection("accounts").document(userId).update(updates).await()
+            Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/example/charactermatchingapp/di/AppModule.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/di/AppModule.kt
@@ -20,6 +20,7 @@ import com.example.charactermatchingapp.presentation.post.PostViewModel
 import com.example.charactermatchingapp.presentation.recommendation.RecommendationViewModel
 import com.example.charactermatchingapp.presentation.SharedViewModel
 import com.example.charactermatchingapp.presentation.matching.CharacterMatchingViewModel
+import com.example.charactermatchingapp.presentation.sns.AccountSettingsViewModel
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -55,4 +56,5 @@ val appModule = module {
     viewModelOf(::CharacterMatchingViewModel)
 
     viewModelOf(::SharedViewModel)
+    viewModelOf(::AccountSettingsViewModel)
 }

--- a/app/src/main/java/com/example/charactermatchingapp/domain/matching/model/Profile.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/domain/matching/model/Profile.kt
@@ -1,12 +1,16 @@
 package com.example.charactermatchingapp.domain.matching.model
 
-import android.net.Uri
+import com.google.firebase.Timestamp
 
-// --- データクラスの定義 ---
 data class Profile(
-    val accountName: String,
-    val headerImageResId: String,
-    val iconImageResId: String,
-    val profileText: String
+    val email: String = "",
+    val displayName: String = "",
+    val iconImageUrl: String? = null,
+    val headerImageUrl: String? = null,
+    val bio: String? = null,
+    val likedCount: Int = 0,
+    val postsCount: Int = 0,
+    val createdAt: Timestamp = Timestamp.now(),
+    val likesTags: List<String> = emptyList()
 )
 

--- a/app/src/main/java/com/example/charactermatchingapp/domain/matching/repository/CharacterMatchingRepository.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/domain/matching/repository/CharacterMatchingRepository.kt
@@ -8,4 +8,5 @@ interface CharacterMatchingRepository {
     suspend fun likeCharacterInfo(characterInfo: CharacterInfo)
     fun bookmarkCharacterInfo(characterInfo: CharacterInfo)
     fun dislikeCharacterInfo(characterInfo: CharacterInfo)
+    suspend fun onCardLiked(userId: String, likedArtworkTags: List<String>): Result<Unit>
 }

--- a/app/src/main/java/com/example/charactermatchingapp/domain/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/domain/user/repository/UserRepository.kt
@@ -1,5 +1,9 @@
 package com.example.charactermatchingapp.domain.user.repository
 
+import com.example.charactermatchingapp.domain.matching.model.Profile
+
 interface UserRepository {
     suspend fun getLikedTags(userId: String): Result<List<String>>
+    suspend fun getUserProfile(userId: String): Result<Profile>
+    suspend fun updateUserProfile(userId: String, profile: Profile): Result<Unit>
 }

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/AccountScreen.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/AccountScreen.kt
@@ -90,17 +90,15 @@ fun AccountScreen(
 @Composable
 fun AccountScreenPreview() {
     val sampleProfile = Profile(
-        accountName = "User Name",
-        headerImageResId = "",
-        iconImageResId = "",
-        profileText = "ここにプロフィール文が入ります。この文章はサンプルです。"
+        displayName = "User Name",
+        bio = "ここにプロフィール文が入ります。この文章はサンプルです。"
     )
 
     val samplePosts = List(50) { i ->
         Post(
             id = i.toString(),
-            userName = sampleProfile.accountName,
-            userIconResId = sampleProfile.iconImageResId,
+            userName = sampleProfile.displayName,
+            userIconResId = sampleProfile.iconImageUrl ?: "", // Handle nullability
             characterName = "キャラ名 $i",
             characterText = "キャラテキスト$i",
             postImageResId = "",

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/AccountSettingsViewModel.kt
@@ -3,6 +3,9 @@ package com.example.charactermatchingapp.presentation.sns
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.charactermatchingapp.domain.auth.service.CurrentUserProvider
+import com.example.charactermatchingapp.domain.matching.model.Profile
+import com.example.charactermatchingapp.domain.user.repository.UserRepository
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,19 +16,22 @@ import kotlinx.coroutines.tasks.await
 
 // UIの状態をすべて保持するデータクラス
 data class AccountSettingsUiState(
-    val headerImageUrl: String = "",
-    val iconImageUrl: String = "",
-    val profileText: String = "",
+    val headerImageUrl: String? = null,
+    val iconImageUrl: String? = null,
+    val profileText: String? = null,
     val isLoading: Boolean = true
 )
 
-class AccountSettingsViewModel : ViewModel() {
+class AccountSettingsViewModel(
+    private val userRepository: UserRepository,
+    private val currentUserProvider: CurrentUserProvider
+) : ViewModel() {
 
     // UIの状態を保持するStateFlow
     private val _uiState = MutableStateFlow(AccountSettingsUiState())
     val uiState: StateFlow<AccountSettingsUiState> = _uiState.asStateFlow()
 
-    private val db = FirebaseFirestore.getInstance()
+    // private val db = FirebaseFirestore.getInstance() // No longer needed
 
     /**
      * 指定されたaccountIdのプロフィール情報をFirestoreから取得する
@@ -33,23 +39,26 @@ class AccountSettingsViewModel : ViewModel() {
     fun loadProfile(accountId: String) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
-            try {
-                val document = db.collection("accounts").document(accountId).get().await()
-                if (document.exists()) {
+            val userId = currentUserProvider.getCurrentUserId()
+            if (userId == null) {
+                _uiState.update { it.copy(isLoading = false) } // Not logged in
+                return@launch
+            }
+
+            userRepository.getUserProfile(userId)
+                .onSuccess { profile ->
                     _uiState.update { currentState ->
                         currentState.copy(
-                            headerImageUrl = document.getString("headerImageUrl") ?: "",
-                            iconImageUrl = document.getString("iconImageUrl") ?: "",
-                            profileText = document.getString("bio") ?: "",
+                            headerImageUrl = profile.headerImageUrl,
+                            iconImageUrl = profile.iconImageUrl,
+                            profileText = profile.bio,
                             isLoading = false
                         )
                     }
-                } else {
-                    _uiState.update { it.copy(isLoading = false) } // データがない場合
                 }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false) } // エラーの場合
-            }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false) } // Error loading profile
+                }
         }
     }
 
@@ -72,14 +81,23 @@ class AccountSettingsViewModel : ViewModel() {
      */
     fun updateProfile(accountId: String) {
         viewModelScope.launch {
+            val userId = currentUserProvider.getCurrentUserId()
+            if (userId == null) return@launch
+
             val currentState = _uiState.value
-            val profileData = hashMapOf(
-                "headerImageUrl" to currentState.headerImageUrl,
-                "iconImageUrl" to currentState.iconImageUrl,
-                "bio" to currentState.profileText
-            )
-            db.collection("accounts").document(accountId).set(profileData).await()
-            // ここで成功・失敗のUIフィードバックを行うことも可能
+
+            userRepository.getUserProfile(userId)
+                .onSuccess { currentProfile ->
+                    val updatedProfile = currentProfile.copy(
+                        headerImageUrl = currentState.headerImageUrl,
+                        iconImageUrl = currentState.iconImageUrl,
+                        bio = currentState.profileText
+                    )
+                    userRepository.updateUserProfile(userId, updatedProfile)
+                        .onSuccess { /* Success feedback */ }
+                        .onFailure { /* Error feedback */ }
+                }
+                .onFailure { /* Error fetching current profile */ }
         }
     }
 }

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/EditableProfileHeader.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/EditableProfileHeader.kt
@@ -46,7 +46,7 @@ fun EditableProfileHeader(
                 painter = if (LocalInspectionMode.current) {
                     painterResource(id = R.drawable.post_example2)
                 } else {
-                    rememberAsyncImagePainter(model = profile.headerImageResId)
+                    rememberAsyncImagePainter(model = profile.headerImageUrl)
                 },
                 contentDescription = "Header Image",
                 modifier = Modifier.fillMaxWidth().height(160.dp),
@@ -56,7 +56,7 @@ fun EditableProfileHeader(
                 painter = if (LocalInspectionMode.current) {
                     painterResource(id = R.drawable.post_example2)
                 } else {
-                    rememberAsyncImagePainter(model = profile.iconImageResId)
+                    rememberAsyncImagePainter(model = profile.iconImageUrl)
                 },
                 contentDescription = "Icon Image",
                 modifier = Modifier
@@ -81,7 +81,7 @@ fun EditableProfileHeader(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = profile.accountName,
+                    text = profile.displayName,
                     fontWeight = FontWeight.Bold,
                     fontSize = 20.sp
                 )
@@ -92,7 +92,7 @@ fun EditableProfileHeader(
                         .padding(vertical = 8.dp)
                 ) {
                     Text(
-                        text = profile.profileText,
+                        text = profile.bio ?: "", // bio can be null
                         modifier = Modifier.fillMaxWidth(),
                         fontSize = 14.sp,
                         textAlign = TextAlign.Center

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/PosterViewAccountScreen.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/PosterViewAccountScreen.kt
@@ -139,17 +139,15 @@ fun PosterViewAccountScreen(
 @Composable
 fun PosterViewAccountScreenPreview() {
     val sampleProfile = Profile(
-        accountName = "User Name",
-        headerImageResId = "",
-        iconImageResId = "",
-        profileText = "ここにプロフィール文が入ります。この文章はサンプルです。"
+        displayName = "User Name",
+        bio = "ここにプロフィール文が入ります。この文章はサンプルです。"
     )
 
     val samplePosts = List(50) { i ->
         Post(
             id = i.toString(),
-            userName = sampleProfile.accountName,
-            userIconResId = sampleProfile.iconImageResId,
+            userName = sampleProfile.displayName,
+            userIconResId = sampleProfile.iconImageUrl ?: "", // Handle nullability
             characterName = "キャラ名 $i",
             characterText = "キャラテキスト$i",
             postImageResId = "",

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/ProfileHeader.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/ProfileHeader.kt
@@ -69,7 +69,7 @@ fun ProfileHeader(
                 painter = if (LocalInspectionMode.current) {
                     painterResource(id = R.drawable.post_example2)
                 } else {
-                    rememberAsyncImagePainter(model = profile.headerImageResId)
+                    rememberAsyncImagePainter(model = profile.headerImageUrl)
                 },
                 contentDescription = "Header Image",
                 modifier = Modifier
@@ -81,7 +81,7 @@ fun ProfileHeader(
                 painter = if (LocalInspectionMode.current) {
                     painterResource(id = R.drawable.post_example2)
                 } else {
-                    rememberAsyncImagePainter(model = profile.iconImageResId)
+                    rememberAsyncImagePainter(model = profile.iconImageUrl)
                 },
                 contentDescription = "Icon Image",
                 modifier = Modifier
@@ -100,7 +100,7 @@ fun ProfileHeader(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = profile.accountName,
+                text = profile.displayName,
                 fontWeight = FontWeight.Bold,
                 fontSize = 20.sp
             )
@@ -111,7 +111,7 @@ fun ProfileHeader(
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 Text(
-                    text = profile.profileText,
+                    text = profile.bio ?: "", // bio can be null
                     modifier = Modifier.fillMaxWidth(),
                     fontSize = 14.sp,
                     textAlign = TextAlign.Center

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/ProfileSettingsScreen.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/ProfileSettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import org.koin.androidx.compose.koinViewModel
 import coil.compose.rememberAsyncImagePainter
 import com.example.charactermatchingapp.R
 import androidx.compose.material3.Surface
@@ -53,7 +54,7 @@ import androidx.compose.material3.TextFieldDefaults
 @Composable
 fun AccountSettingsScreen(
     accountId: String,
-    viewModel: AccountSettingsViewModel = viewModel(), // ViewModelを取得
+    viewModel: AccountSettingsViewModel = koinViewModel(), // ViewModelを取得
     onClick: () -> Unit
 ) {
     // ViewModelのUI状態を監視
@@ -120,7 +121,7 @@ fun AccountSettingsScreen(
                                 .clickable { headerLauncher.launch("image/*") },
                             contentAlignment = Alignment.Center
                         ) {
-                            if (uiState.headerImageUrl.isEmpty()) {
+                            if (uiState.headerImageUrl.isNullOrEmpty()) {
                                 Image(painter = painterResource(id = R.drawable.post_example2),
                                     contentDescription = "Header Placeholder",
                                     modifier = Modifier.fillMaxSize(),
@@ -154,7 +155,7 @@ fun AccountSettingsScreen(
                                 .clickable { iconLauncher.launch("image/*") },
                             contentAlignment = Alignment.Center
                         ) {
-                            if (uiState.iconImageUrl.isEmpty()) {
+                            if (uiState.iconImageUrl.isNullOrEmpty()) {
                                 Image(painter = painterResource(id = R.drawable.post_example2),
                                     contentDescription = "Icon Placeholder",
                                     modifier = Modifier.fillMaxSize(),
@@ -186,7 +187,7 @@ fun AccountSettingsScreen(
                                 color = MaterialTheme.colorScheme.primary
                                 )
                             OutlinedTextField(
-                                value = uiState.profileText,
+                                value = uiState.profileText ?: "", // Handle nullability for TextField
                                 onValueChange = viewModel::onProfileTextChange, // ViewModelの関数を呼び出す
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/app/src/main/java/com/example/charactermatchingapp/presentation/sns/TimelineScreen.kt
+++ b/app/src/main/java/com/example/charactermatchingapp/presentation/sns/TimelineScreen.kt
@@ -128,16 +128,14 @@ fun TimelineScreen(
 @Composable
 fun TimelineScreenPreview() {
     val sampleProfile = Profile(
-        accountName = "User Name",
-        headerImageResId = "",
-        iconImageResId = "",
-        profileText = "ここにプロフィール文が入ります。この文章はサンプルです。"
+        displayName = "User Name",
+        bio = "ここにプロフィール文が入ります。この文章はサンプルです。"
     )
     val samplePosts = List(50) { i ->
         Post(
             id = i.toString(),
-            userName = sampleProfile.accountName,
-            userIconResId = sampleProfile.iconImageResId,
+            userName = sampleProfile.displayName,
+            userIconResId = sampleProfile.iconImageUrl ?: "", // Handle nullability
             characterName = "キャラ名 $i",
             characterText = "キャラテキスト$i",
             postImageResId = "",


### PR DESCRIPTION
いいねしたときにlikesTags重複無し追加保存

SNSのプロフィール編集ボタンから遷移する編集ページで更新したときに、プロフィール以外のデータが消えてしまうバグを解消